### PR TITLE
voltage: fix NPE crash in getCPUTemp causing SystemUI Doze crash loop

### DIFF
--- a/core/java/com/android/internal/util/voltage/VoltageUtils.java
+++ b/core/java/com/android/internal/util/voltage/VoltageUtils.java
@@ -191,7 +191,14 @@ public class VoltageUtils {
         }
         int cpuTempMultiplier = context.getResources().getInteger(
                 com.android.internal.R.integer.config_sysCPUTempMultiplier);
-        return value == "Error" ? "N/A" : String.format("%s", Integer.parseInt(value) / cpuTempMultiplier) + "°C";
+        if (value == null || value.trim().isEmpty() || "Error".equals(value)) {
+            return "N/A";
+        }
+        try {
+            return String.format("%s", Integer.parseInt(value.trim()) / cpuTempMultiplier) + "°C";
+        } catch (NumberFormatException e) {
+            return "N/A";
+        }
     }
     public static boolean fileExists(String filename) {
         if (filename == null) {


### PR DESCRIPTION
## Problem
getCPUTemp() only checks `value == "Error"` before calling
Integer.parseInt(value), but readOneLine() can also return null
(e.g. when the sysfs node exists but is empty/unreadable). This
causes an unhandled NumberFormatException.

On devices where this happens during Doze entry, the crash is
thrown from KeyguardIndicationController -> DozeServiceHost ->
DozeMachine.transitionTo(), which crashes SystemUI mid-transition
and causes a screen-off/restart loop.

## Fix
- Added null/empty check before parsing
- Changed String equality check from `==` to `.equals()`
- Wrapped parseInt in try/catch as a safety net against any future
  non-numeric sysfs output

## Testing
Reproduced consistently on device (Motorola sm6375, Android 17
based build) via logcat showing FATAL EXCEPTION in
com.android.systemui with NumberFormatException: s == null at
VoltageUtils.java:194. Confirmed fixed after patch — no further

# note
this only affects devices where config_cpu_temp_path points to a node that can return empty