### PR TITLE
SystemUI: fix duplicate static_libs in rules.ui_dagger

### DIFF
--- a/packages/SystemUI/pods/notifications/intelligence/rules/ui/Android.bp
+++ b/packages/SystemUI/pods/notifications/intelligence/rules/ui/Android.bp
@@ -61,9 +61,11 @@ java_library {
     name: "com.android.systemui.notifications.intelligence.rules.ui_dagger",
     defaults: ["sysui_dagger"],
     static_libs: [
+        "com.android.systemui.notifications.intelligence.rules.ui_main",
+    ],
+    libs: [
         "com.android.systemui.notifications.intelligence.rules_main",
         "com.android.systemui.notifications.intelligence.rules_dagger",
-        "com.android.systemui.notifications.intelligence.rules.ui_main",
     ],
 }
 


### PR DESCRIPTION
rules_main and rules_dagger are already statically linked in the bundle target. Listing them as static_libs here causes turbine to process duplicate classes and produce an invalid zip archive.

Move them to libs (compile-time classpath) instead, keeping only ui_main as static.